### PR TITLE
Use Renovate instead of Dependabot for go-github updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,7 @@ updates:
     cooldown:
       default-days: 7
   ###########################################################
+
+    ignore:
+      # Update with renovate
+      - dependency-name: "github.com/google/go-github*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices"
+  ],
+  "minimumReleaseAge": "7 days",
+  "enabledManagers": ["gomod"],
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Disable all package updates except for go-github",
+      "excludePackagePatterns": [
+        "^github\\.com/google/go-github(/.*)?$"
+      ],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Dependabot cannot handle major version updates involving import path changes for Go modules. This commit introduces Renovate specifically for updating github.com/google/go-github.